### PR TITLE
Fix: Buffer string that might become a dangling pointer

### DIFF
--- a/source/iopipe/json/parser.d
+++ b/source/iopipe/json/parser.d
@@ -378,9 +378,8 @@ struct JSONItem
      * Given an iopipe from which this token came, returns the exact window
      * data for the item.
      *
-     * WARNING:	For any given JSONItem, calling this function is only valid until the next call to peek/next.
-     * 		You have to copy the string if you can't use it immediately.
-     * 		The returned string also gets invalidated on peek/next.
+     * WARNING:	A JSONItem can only safely call this function before the item is released with "releaseParsed".
+     * 		Additionally, the returned string gets invalidated on calls to peek/next/releaseParsed.
      */
     auto data(Chain)(ref Chain c)
     {

--- a/source/iopipe/json/parser.d
+++ b/source/iopipe/json/parser.d
@@ -377,6 +377,10 @@ struct JSONItem
     /**
      * Given an iopipe from which this token came, returns the exact window
      * data for the item.
+     *
+     * WARNING:	For any given JSONItem, calling this function is only valid until the next call to peek/next.
+     * 		You have to copy the string if you can't use it immediately.
+     * 		The returned string also gets invalidated on peek/next.
      */
     auto data(Chain)(ref Chain c)
     {

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -575,13 +575,14 @@ OBJ_MEMBER_SWITCH:
                 // any extras should be put in here
                 JSONValue!SType newItem;
                 tokenizer.deserializeImpl(newItem, relPol);
-                __traits(getMember, item, extrasMember).object[name.to!(immutable(SType))] = newItem;
+		auto copyIfNeeded = (string s) => (s.ptr != namebuffer.ptr) ? s : s.idup;
+                __traits(getMember, item, extrasMember).object[copyIfNeeded(name).to!(immutable(SType))] = newItem;
                 break OBJ_MEMBER_SWITCH;
             }}
             else
             {
                 import std.format : format;
-                throw new JSONIopipeException(format("No member named '%s' in type `%s`", name, T.stringof));
+                throw new JSONIopipeException(format("No member named '%s' in type `%s`", name.idup, T.stringof));
             }
         }
         // shut up compiler

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -512,15 +512,16 @@ void deserializeAllMembers(T, JT)(ref JT tokenizer, ref T item, ReleasePolicy re
         }
         else
             jsonExpect(jsonItem, JSONToken.String, "Expecting member name of " ~ T.stringof);
-        char[32] namebuffer = void;
-        string name = {
+	alias CharT = Unqual!(typeof(jsonItem.data(tokenizer.chain)[0]));
+        CharT[32] namebuffer = void;
+        auto name = {
                 // Need to buffer the name, as following calls of "nextSignificant" may call extend, which invalidates the window
                 const window = jsonItem.data(tokenizer.chain);
                 if(window.length <= namebuffer.length)
                 {
-                        char[] retbuf = namebuffer[0..window.length];
+                        CharT[] retbuf = namebuffer[0..window.length];
                         retbuf[] = window[];
-                        return cast(immutable char[]) retbuf;
+                        return cast(immutable CharT[]) retbuf;
                 }
                 else
                 {


### PR DESCRIPTION
The value "name" is a slice from the buffer of the chain. tokenizer.nextSignificant will call extend, which might move the data inside the chain or even reallocate and cause segfaults. Inside the switch statement, release is also called sometimes. I don't know how switch in D is implement, but I don't think that it will buffer the string for each case-comparison, thus this is still dangerous.