### PR TITLE
Implement leaveNestingLevel

### DIFF
--- a/source/iopipe/json/parser.d
+++ b/source/iopipe/json/parser.d
@@ -1660,7 +1660,7 @@ struct JSONTokenizer(Chain, ParseConfig cfg)
     
 
     /** Seek until leaving the current object or array. 
-     * When next item will be ObjectStart or ArrayStart, will behave exactly as JSONItem.skipItem()
+     * When next item will be ObjectStart or ArrayStart, will behave similar to JSONItem.skipItem(), but without consuming the ArrayEnd/ObjectEnd
      
      * Params:
      * 	 depth = How many levels to leave. 1-indexed

--- a/source/iopipe/json/parser.d
+++ b/source/iopipe/json/parser.d
@@ -1657,6 +1657,45 @@ struct JSONTokenizer(Chain, ParseConfig cfg)
             cast(void)next; // skip this item
         }
     }
+    
+
+    /** Seek until leaving the current object or array. 
+     * When next item will be ObjectStart or ArrayStart, will behave exactly as JSONItem.skipItem()
+     
+     * Params:
+     * 	 depth = How many levels to leave. 1-indexed
+     * Returns:
+     * 	 The last item consumed, so either a closing ArrayEnd or ObjectEnd or EOF
+     */
+    JSONItem leaveNestingLevel(long depth=1)
+    { 
+        assert(depth >= 1, "Leaving less than 0 level would make no sense.");
+
+        with(JSONToken) for(auto item = next;;item = next)
+            switch(item.token)
+            {
+                case ArrayStart:
+                case ObjectStart:
+                    depth++;
+                    break;
+                case ArrayEnd:
+                case ObjectEnd:
+                    if(depth == 1)
+                    {
+                        // Do not consume so caller can differentiate between Array and Object
+                        return item;
+                    }
+                    depth--;
+                    break;
+                case EOF:
+                    return item;
+                default:
+                    break;
+            }
+        assert(0, "Impossible");
+    }
+    
+    
 
     /// Consume any spaces and/or comments. Returns the next token after those are skipped.
     JSONToken peekSignificant()
@@ -2155,6 +2194,32 @@ unittest
         assert(parser.cache.length == 0);
         assert(parser.cIdx == 0);
         assert(check(parser.next, ObjectEnd, "}"));
+    }
+}
+
+// leaveNestingLevel
+unittest
+{
+    string jsonData = `{"a" : [1, 2, 3], "b" : {"c" : {"d": 2, "e": 3}}, "f": 3}`;
+    auto parser = jsonData.jsonTokenizer!(ParseConfig(false));
+    bool check(JSONItem item, JSONToken token, string expected)
+    {
+        if(item.token == token && item.data(parser.chain) == expected)
+            return true;
+        import std.stdio;
+        writeln(item);
+        return false;
+    }
+
+    with(JSONToken)
+    {
+        assert(parser.parseTo("b", "c", "d"));
+        assert(check(parser.next, Number, "2"));
+        assert(check(parser.leaveNestingLevel(2), ObjectEnd, "}"));
+        assert(check(parser.next, Comma, ","));
+        assert(check(parser.next, String, "f"));
+        assert(check(parser.leaveNestingLevel, ObjectEnd, "}"));
+        assert(check(parser.leaveNestingLevel, EOF, ""));
     }
 }
 

--- a/source/iopipe/json/parser.d
+++ b/source/iopipe/json/parser.d
@@ -1667,7 +1667,7 @@ struct JSONTokenizer(Chain, ParseConfig cfg)
      * Returns:
      * 	 The last item consumed, so either a closing ArrayEnd or ObjectEnd or EOF
      */
-    JSONItem leaveNestingLevel(long depth=1)
+    JSONItem leaveNestingLevel(ulong depth=1)
     { 
         assert(depth >= 1, "Leaving less than 0 level would make no sense.");
 


### PR DESCRIPTION
Another utility that is similar to skipItem, but supports leaving arbitrary amounts of levels. Useful for when you have to parse deeply nested objects, at some point building deeply nested structs to use with `deserialize` becomes annoying. That said, `deserialize` accepting some kind of path as an uda to simlate this could help.

Issues: 
* This might be out of scope for this library as this utility is only marginally useful
* 1-indexed input argument. It sounds reasonable in natural language but might lead to annoyances if real code where you might have a 0-indexed depth variable (as is done in other places here)
* Argument type of parameter: `ulong` or `long`? The value range doesn't matter, but maybe the compiler will less often force you to do an annoying cast on either of those (just template it?)