### PR TITLE
Serialize small improvements

### DIFF
--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -179,10 +179,12 @@ unittest {
 
 /**
  * Expect the given JSONItem to be a specific token.
+ * Parameters:
+ *      msg: Optional error message to display
  * Throws:
  *	JSONIopipeException on violation.
  */
-void jsonExpect(JSONItem item, JSONToken expectedToken, string msg, string file = __FILE__, size_t line = __LINE__) pure @safe
+void jsonExpect(JSONItem item, JSONToken expectedToken, string msg="Error", string file = __FILE__, size_t line = __LINE__) pure @safe
 {
     if(item.token != expectedToken)
     {

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -1128,7 +1128,6 @@ void serializeAllMembers(T, Char)(scope void delegate(const(Char)[]) w, auto ref
 
 void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, ref T val) if (is(T == struct))
 {
-    import std.sumtype;
     static if(isInstanceOf!(Nullable, T))
     {
         if(val.isNull)
@@ -1178,10 +1177,6 @@ void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, ref T val) if 
             w(val.boolean ? "true" : "false");
             break;
         }
-    }
-    else static if(isInstanceOf!(SumType, T))
-    {
-        val.match!( v => serializeImpl(w,v));
     }
     else static if(__traits(hasMember, T, "toJSON"))
     {
@@ -1236,16 +1231,6 @@ void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, T val) if (is(
         serializeAllMembers(w, val);
         w("}");
     }
-}
-
-// serialize sumtype
-unittest
-{
-    import std.sumtype;
-    alias S = SumType!(int, string);
-
-    S[2] s = [S(3), S("test")];
-    assert(serialize(s) == `[3, "test"]`);
 }
 
 // null class members

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -30,7 +30,6 @@ import std.meta;
 import std.typecons : Nullable;
 import std.conv;
 import std.format;
-import std.sumtype;
 
 // define some UDAs to affect serialization
 struct IgnoredMembers { string[] ignoredMembers; }
@@ -1068,7 +1067,6 @@ void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, T val) if (is(
 
 unittest
 {
-    import std.stdio;
     auto serialized = serialize(["a" : 1, "b": 2]);
     assert(serialized == `{"a" : 1, "b" : 2}` || serialized == `{"b" : 2, "a" : 1}`);
     enum X
@@ -1127,6 +1125,7 @@ void serializeAllMembers(T, Char)(scope void delegate(const(Char)[]) w, auto ref
 
 void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, ref T val) if (is(T == struct))
 {
+    import std.sumtype;
     static if(isInstanceOf!(Nullable, T))
     {
         if(val.isNull)
@@ -1239,6 +1238,7 @@ void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, T val) if (is(
 // serialize sumtype
 unittest
 {
+    import std.sumtype;
     alias S = SumType!(int, string);
 
     S[2] s = [S(3), S("test")];

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -30,6 +30,7 @@ import std.meta;
 import std.typecons : Nullable;
 import std.conv;
 import std.format;
+import std.sumtype;
 
 // define some UDAs to affect serialization
 struct IgnoredMembers { string[] ignoredMembers; }
@@ -1175,6 +1176,10 @@ void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, ref T val) if 
             break;
         }
     }
+    else static if(isInstanceOf!(SumType, T))
+    {
+        val.match!( v => serializeImpl(w,v));
+    }
     else static if(__traits(hasMember, T, "toJSON"))
     {
         val.toJSON(w);
@@ -1228,6 +1233,15 @@ void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, T val) if (is(
         serializeAllMembers(w, val);
         w("}");
     }
+}
+
+// serialize sumtype
+unittest
+{
+    alias S = SumType!(int, string);
+
+    S[2] s = [S(3), S("test")];
+    assert(serialize(s) == `[3, "test"]`);
 }
 
 // null class members

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -679,8 +679,9 @@ unittest
 
 
 /** Deserialize the given type from the JSON data.
+ * Note that all arrays are also iopipes, so you can pass in a `string` for `c`.
  * Throws:
- * 	JSONIopipeException on parser error.
+ *      JSONIopipeException on parser error.
  */
 T deserialize(T, JT)(ref JT tokenizer, ReleasePolicy relPol = ReleasePolicy.afterMembers) if (isInstanceOf!(JSONTokenizer, JT))
 {
@@ -689,7 +690,7 @@ T deserialize(T, JT)(ref JT tokenizer, ReleasePolicy relPol = ReleasePolicy.afte
     return result;
 }
 
-/// `Chain c` will accept a string too.
+/// ditto
 T deserialize(T, Chain)(auto ref Chain c) if (isIopipe!Chain)
 {
     enum shouldReplaceEscapes = is(typeof(chain.window[0] = chain.window[1]));
@@ -697,11 +698,13 @@ T deserialize(T, Chain)(auto ref Chain c) if (isIopipe!Chain)
     return tokenizer.deserialize!T(ReleasePolicy.afterMembers);
 }
 
+/// ditto
 void deserialize(T, JT)(ref JT tokenizer, ref T item, ReleasePolicy relPol = ReleasePolicy.afterMembers) if (isInstanceOf!(JSONTokenizer, JT))
 {
     deserializeImpl(tokenizer, item, relPol);
 }
 
+/// ditto
 void deserialize(T, Chain)(auto ref Chain c, ref T item) if (isIopipe!Chain)
 {
     enum shouldReplaceEscapes = is(typeof(chain.window[0] = chain.window[1]));

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -1355,16 +1355,18 @@ mixin template VirtualToJSON()
     }
 }
 
-// Class based runtime polymorphism helpers
+/// Class based runtime polymorphism helpers
 unittest
 {
-    static class C : JSONSerializable {
+    static class C : JSONSerializable 
+    {
         this(int x){this.x = x;}
         int x;
         mixin VirtualToJSON;
 
     }
-    static class D: JSONSerializable {
+    static class D: JSONSerializable 
+    {
         this(string s){this.s=s;}
         string s;
         mixin VirtualToJSON;

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -690,6 +690,7 @@ T deserialize(T, JT)(ref JT tokenizer, ReleasePolicy relPol = ReleasePolicy.afte
     return result;
 }
 
+/// `Chain c` will accept a string too.
 T deserialize(T, Chain)(auto ref Chain c) if (isIopipe!Chain)
 {
     enum shouldReplaceEscapes = is(typeof(chain.window[0] = chain.window[1]));

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -1332,50 +1332,6 @@ string serialize(T)(auto ref T val)
     return result.assumeUnique;
 }
 
-/**
- * Use with `mixin VirtualToJSON()` for runtime polymorphism
- */
-interface JSONSerializable 
-{
-    void toJSON(scope void delegate(const(char)[]) w) const;
-}
-
-/**
- * Mixin that creates a toJSON method that behaves exactly as if the class didn't 
- * have a toJSON method and this library would try to serialize an object by itself.
- 
- * This can be used for runtime polymorphism as an alternative to SumType.
- */
-mixin template VirtualToJSON() 
-{
-    void toJSON(scope void delegate(const(char)[]) w) const 
-    {
-        w("{");
-            serializeAllMembers(w, this);
-        w("}");
-    }
-}
-
-/// Class based runtime polymorphism helpers
-unittest
-{
-    static class C : JSONSerializable 
-    {
-        this(int x){this.x = x;}
-        int x;
-        mixin VirtualToJSON;
-
-    }
-    static class D: JSONSerializable 
-    {
-        this(string s){this.s=s;}
-        string s;
-        mixin VirtualToJSON;
-    }
-    JSONSerializable[] n = cast(JSONSerializable[])[new C(5), new D("test")];
-    assert(serialize(n) == `[{"x" : 5}, {"s" : "test"}]`);
-}
-
 unittest
 {
     auto str1 = serialize(1);


### PR DESCRIPTION
jsonExcept was a little too unwieldy when using it excessively and you don't want to give an errormessage because it's obvious from context in some cases