### PR TITLE
Fix #22, deserializing a string should take care of all the escapes,

### DIFF
--- a/source/iopipe/json/dom.d
+++ b/source/iopipe/json/dom.d
@@ -50,34 +50,8 @@ private JSONValue!SType buildValue(SType, Tokenizer)(ref Tokenizer parser, JSONI
         {
             JT result;
             result.type = JSONType.String;
-            if(item.hint == JSONParseHint.InPlace)
-            {
-                // get the data
-                // TODO: need to duplicate, even if it's the same type
-                result.str = item.data(parser.chain).to!SType;
-                return result;
-            }
-            else
-            {
-                // put the quotes back
-                item.offset--;
-                item.length += 2;
-
-                // re-parse, this time replacing escapes. This is so ugly...
-                static if(is(typeof(newpipe[] = parser.chain.window[])))
-                {
-                    auto newpipe = new Unqual!(typeof(SType.init[0]))[item.length];
-                    newpipe[] = item.data(parser.chain);
-                }
-                else
-                {
-                    auto newpipe = item.data(parser.chain).to!(Unqual!(typeof(SType.init[0]))[]);
-                }
-                size_t pos = 0;
-                auto len = parseString(newpipe, pos, item.hint);
-                result.str = cast(typeof(result.str))newpipe[1 .. 1 + len];
-                return result;
-            }
+            result.str = extractString!SType(item, parser.chain);
+            return result;
         }
     case Number:
         {

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -421,8 +421,7 @@ private void deserializeImpl(T, JT)(ref JT tokenizer, ref T item, ReleasePolicy)
     jsonExpect(jsonItem, JSONToken.String, "Parsing " ~ T.stringof);
 
     // this should not fail unless the data is non-unicode
-    // TODO: may need to copy the data if not immutable
-    item = jsonItem.data(tokenizer.chain).to!T;
+    item = extractString!T(jsonItem, tokenizer.chain);
 }
 
 private template SerializableMembers(T)
@@ -1533,4 +1532,13 @@ unittest
     auto tokenizer = `[{"x": 1},{"x": 2}]`.jsonTokenizer;
 
     assert(tokenizer.deserialize!(S[2]) == [S(1), S(2)]);
+}
+
+// issue #22
+unittest
+{
+    import std.stdio;
+    string json = `"\"test\n1\\2\""`;
+	string str = deserialize!string(json);
+	assert(str == "\"test\n1\\2\"");
 }


### PR DESCRIPTION
even if the source iopipe is not updated in-place.