### PR TITLE
Escape strings

### DIFF
--- a/source/iopipe/json/parser.d
+++ b/source/iopipe/json/parser.d
@@ -1504,7 +1504,7 @@ JSONItem jsonItem(ParseConfig config = ParseConfig.init, Chain)(ref Chain c, ref
  */
 struct JSONTokenizer(Chain, ParseConfig cfg)
 {
-    alias config = cfg;
+    enum config = cfg;
     import std.bitmanip : BitArray;
 
     /**

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -1083,8 +1083,12 @@ unittest
 
 void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, T val) if (isSomeString!T)
 {
+    import std.algorithm.iteration: substitute;
     w(`"`);
-    put(w, val);
+    put(w, val.substitute!(
+                `"`, `\"`,
+                `\`, `\\`,
+        ));
     w(`"`);
 }
 

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -1088,6 +1088,20 @@ void serializeImpl(T, Char)(scope void delegate(const(Char)[]) w, T val) if (isS
     w(`"`);
 }
 
+// Escape special characters
+unittest
+{
+    string raw = `\ and " must be escaped!`;
+    assert(raw.serialize == `"\\ and \" must be escaped!"`);
+}
+
+// Special characters must survive roundtrip.
+unittest
+{
+    string raw = `\ and " must be escaped!`;
+    assert(raw.serialize.deserialize!string == raw);
+}
+
 void serializeAllMembers(T, Char)(scope void delegate(const(Char)[]) w, auto ref T val)
 {
     // serialize as an object

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -424,8 +424,13 @@ private void deserializeImpl(T, JT)(ref JT tokenizer, ref T item, ReleasePolicy)
     static if(JT.config.replaceEscapes)
     {
         // this should not fail unless the data is non-unicode
-        // TODO: may need to copy the data if not immutable
-        item = onChain.to!T;
+        auto s = onChain.to!T;
+        // I couldn't find anything in the `to` docs that guarantees that is copies strings.
+        // In practice it does, but check it just to be sure
+        if(s.ptr != onChain.ptr)
+            item = s;
+        else
+            item = s.idup;
     }
     else
     {

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -1099,6 +1099,16 @@ unittest
     assert(raw.serialize == `"\\ and \" must be escaped!"`);
 }
 
+// Special characters get removed with replaceEscapes
+unittest
+{
+    // replaceEscapes only works with mutable chains
+    auto c = `"\\ and \" must be escaped!"`.dup;
+    string expected = `\ and " must be escaped!`;
+    auto tokenizer = c.jsonTokenizer!(ParseConfig(replaceEscapes: true));
+    assert(tokenizer.deserialize!string == expected);
+}
+
 // Special characters must survive roundtrip.
 unittest
 {


### PR DESCRIPTION
Some changes around escaped strings:
* serialize will now escape special characters
* deserialize will unescape characters in the case that `replaceEscapes` is disabled, since in that case the JSONTokenizer already handles this

The code is a bit of a mess, it has a bunch of duplicated code with JSONTokenizer since it duplicates the replaceEscape logic. I don't want invest more effort in case you deem this out of scope for this library. I will clean this up and add more tests once you indicate that these changes are directionally alright.