### PR TITLE
add caseInsensitive feature

### DIFF
--- a/source/iopipe/json/parser.d
+++ b/source/iopipe/json/parser.d
@@ -68,6 +68,9 @@ struct ParseConfig
      * the comment delimeters.
      */
     bool includeComments;
+
+    bool propertyNameCaseInsensitive;
+
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds support for case-insensitive property name matching during deserialization.

As part of this change, a new compile-time template `GetJsonName!(item, m)` was introduced to reduce code duplication when determining the JSON field name.