### PR TITLE
maxDepth option added

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,6 +1,6 @@
 name "jsoniopipe"
 description "JSON and JSON5 parser for iopipe"
-authors "Steven Schveighoffer"
+authors "Steven Schveighoffer, Gaofei Qiu"
 copyright "Copyright © 2017, Steven Schveighoffer"
 license "boost"
 targetType "library"

--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -32,10 +32,16 @@ import std.conv;
 import std.format;
 
 struct DefaultDeserializationPolicy {
+    int maxDepthAvailable = 64; // default depth
     ReleasePolicy relPol = ReleasePolicy.afterMembers; // default policy
 
     // Called at beginning of struct/class deserialization
     bool[SerializableMembers!T.length] onObjectBegin(JT, T)(ref JT tokenizer) {
+
+        if (maxDepthAvailable <= 0) {
+            throw new JSONIopipeException("Maximum deserialization depth exceeded");  
+        }
+        maxDepthAvailable--;
         
         // Pre-mark optional fields as visited
         alias members = SerializableMembers!T;
@@ -1230,7 +1236,13 @@ unittest
         }
     }`; 
 
-    auto person = deserializeWithPolicy!(Person)(jsonStr);
+    auto policy1 = DefaultDeserializationPolicy(1); // Set max depth to 1
+    assertThrown!JSONIopipeException(
+        deserializeWithPolicy!(Person, DefaultDeserializationPolicy)(jsonStr, policy1)
+    );
+
+    auto policy2 = DefaultDeserializationPolicy(2); // Set max depth to 2
+    auto person = deserializeWithPolicy!(Person, DefaultDeserializationPolicy)(jsonStr, policy2);
     assert(person.firstName == "John");
     assert(person.lastName == "Doe");
     assert(person.age == 30);


### PR DESCRIPTION
This adds back the `maxDepth` parameter to `DefaultDeserializationPolicy`, which was removed before merging the initial policy-based deserialization support.

The `maxDepth` option limits the maximum nesting depth during JSON deserialization to prevent stack overflows and resource exhaustion attacks caused by deeply nested or malicious input. 
