### PR TITLE
Update policy handling to start following new design

### DIFF
--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -56,7 +56,7 @@ struct DefaultDeserializationPolicy {
         string key,
         ref bool[N] visited
     ) {
-        static assert(N == SerializeableMembers!T);
+        static assert(N == SerializableMembers!T.length);
         alias members = SerializableMembers!T;
         alias ignoredMembers = AllIgnoredMembers!T;
         // Check each member to see if it matches
@@ -108,7 +108,7 @@ struct DefaultDeserializationPolicy {
     
     // Called at end of deserialization
     void onObjectEnd(JT, T, size_t N)(ref JT tokenizer, ref T item, ref bool[N] visited) {
-        static assert(N == SerializeableMembers!T);
+        static assert(N == SerializableMembers!T.length);
 
         if(this.relPol == ReleasePolicy.afterMembers)
             tokenizer.releaseParsed();
@@ -1231,6 +1231,12 @@ unittest
     assert(person.firstName == "John");
     assert(person.lastName == "Doe");
     assert(person.age == 30);
+
+    // verify deserialize item with policy compiles as expected
+    auto policy = DefaultDeserializationPolicy();
+    Person p;
+    auto tokenizer = jsonStr.jsonTokenizer!(ParseConfig(false));
+    static assert(__traits(compiles, deserializeImplWithPolicy(policy, tokenizer, p)));
 }
 
 


### PR DESCRIPTION
Also cleaned up some explicit instantiations.

@gulugulubing this is a start to implement [the new policy design](https://github.com/schveiguy/jsoniopipe/wiki/Serialization-Policy).

The main hook to call is `deserializeItem`, and it will call all the correct functions depending on what the policy wants to do.

At some point soon, I want to remove the `deserializeWithPolicy`, and just change all the `deserializeImpl` to use the policy.