### PR TITLE
fromJSON: Refactoring and usability

### DIFF
--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -705,7 +705,7 @@ private template checkRef(alias FromJSON, JT, P)
     else static if(__traits(compiles,FromJSON!(JT, P)))
         enum checkRef = isJTRef!(FromJSON!(JT, P));
     else
-        static assert(0, "Precondition violated. FromJSON must take template parameters JT and P in any order");
+        static assert(0, "Precondition violated. fromJSON with Policy must only take template parameters JT and P, in any order");
 }
 
 void deserializeImpl(P, T, JT)(ref P policy, ref JT tokenizer, ref T item) if (is(T == struct) && __traits(hasMember, T, "fromJSON"))


### PR DESCRIPTION
Since this repo seems to stabilize again, I'm porting my stuff over and document/ fix where migrating is painful.

`fromJSON` is kind of a problem, since multiple template signatures of `fromJSON` are supported. This means, afaik, that `__traits(compiles, ...)` has to be used to choose the correct one. If `fromJSON` uses ReleasePolicy and contains another error, the compiler message will be pretty bad and even send you on a wrong path (trying to call it with `Policy`)

If your fromJSON failed to compile and it had two template parameters in the wrong order, you'd get compiler errors that "DefaultDeserializationPolicy doesn't have memberfunction next/ peek".

This PR slightly improved the error messages and the set of valid function signatures so hopefully the migration is less of a hassle.

Alternatively, we could refactor the whole call chain of deserializeImpl to pass a ReleasePolicy instead of a Policy so IFTI can just be used and print useful errors, but that is probably more headache than its worth. We could also introduce `fromJSONv2` for Policy and leave the old one as it was. I both these ideas are not necessary, as is should hopefully be rare that fromJSON with releasePolicy fails to compile while upgrading this library. I think the most likely case that hit this is if you explicitly typed the return value of `tokenizer.next` as `JSONItem` instead of using `auto` since the type changed.


