### PR TITLE
Make policy Autoref + some QOL stuff for deserialization

### DIFF
--- a/source/iopipe/json/serialize.d
+++ b/source/iopipe/json/serialize.d
@@ -1565,7 +1565,7 @@ unittest
 void deserialize(T, JT, Policy)(
     ref JT tokenizer,
     ref T item,
-    Policy policy
+    auto ref Policy policy
 ) if (isInstanceOf!(JSONTokenizer, JT))
 {
     policy.deserializeImpl(tokenizer, item);
@@ -1573,7 +1573,7 @@ void deserialize(T, JT, Policy)(
 
 T deserialize(T, JT, Policy)(
     ref JT tokenizer,
-    Policy policy
+    auto ref Policy policy
 ) if (isInstanceOf!(JSONTokenizer, JT))
 {
     T result;
@@ -1609,7 +1609,7 @@ T deserialize(T, Chain)(
 
 T deserialize(T, Policy, Chain)(
     auto ref Chain c,
-    Policy policy
+    auto ref Policy policy
 ) if (isIopipe!Chain)
 {
     enum shouldReplaceEscapes = is(typeof(c.window[0] = c.window[1]));


### PR DESCRIPTION
Fix #76 and make policy for `deserialize` autoref

Also make policy autoref for the helpers, like `deserializeObject`, `deserializeImpl`. They were already ref before, so this is just QOL, but since they're public per #79, it makes sense to make this small change.

Allow deserializeObj to return the Item instead of only taking it by ref. 
This doesn't make sense yet for deserializeArray, due to it still needing some work. Right now it only works reliably for appender.